### PR TITLE
Remove unneeded code, add missing support for zoom, and adjust CSS

### DIFF
--- a/unpacked/jax/output/PlainSource/config.js
+++ b/unpacked/jax/output/PlainSource/config.js
@@ -29,15 +29,15 @@ MathJax.OutputJax.PlainSource = MathJax.OutputJax({
   extensionDir: MathJax.OutputJax.extensionDir + "/PlainSource",
 
   config: {
-    matchFontHeight: false,   // try to match math font height to surrounding font?
-    scale: 100,              // scaling factor for all math
-    minScaleAdjust: 50,      // minimum scaling to adjust to surrounding text
-                             //  (since the code for that is a bit delicate)
-
     styles: {
-      "div.MathJax_PlainSource": {
+      ".MathJax_PlainSource_Display": {
         "text-align": "center",
-        margin: ".75em 0px"
+        margin: ".75em 0px",
+        "white-space":"pre"
+      },
+      ".MathJax_PlainSource_Display > span": {
+        display: "inline-block",
+        "text-align": "left"
       }
     }
   }


### PR DESCRIPTION
This pull request adjusts the following:

* CSS changed to format displayed equations better
* Unneeded code removed.
* Code added to actually insert the style definitions
* Additional `<span>` used inside the frame, since this is assumed by the AssistiveMML extension
* Use `HTML.addText()` rather than `innerHTML` so that the source will not be interpreted as HTML (in particular, `&`, `<`, etc., will not cause problems this way).
* Save the source once it is found so that it can be used for the Zoom function.
* The `hideProcessedMath` variable and `MathJax_Processed` class are not needed, since this code will not do any restarts (it never needs to load any auxiliary files).  So there is no need for the extra machinery for hiding things during that process.
* Same for the previews -- they can just be removed.
* That means `postTranslate()` doesn't have to do anything.
* Add required support for Zoom functionality.
